### PR TITLE
Added Conan support for 3rd party libraries and modified cmake

### DIFF
--- a/.github/workflows/ros2-liodom-build.yml
+++ b/.github/workflows/ros2-liodom-build.yml
@@ -1,0 +1,64 @@
+name: ROS2 Liodom Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Add ROS 2 apt sources
+        run: |
+            sudo apt install software-properties-common
+            sudo add-apt-repository universe
+            sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc -o /etc/apt/trusted.gpg.d/ros.asc
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/trusted.gpg.d/ros.asc] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+      - name: Install packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            ros-kilted-desktop \
+            ros-kilted-pcl-ros \
+            ros-kilted-pcl-conversions \
+            build-essential \
+            python3 \
+            python-is-python3 \
+            pipx \
+            cmake \
+            libudev-dev \
+            python3-colcon-common-extensions \
+            ros-kilted-ament-cmake
+
+      - name: Install Conan and detect compilers
+        run: |
+          pipx install conan
+          conan profile detect
+
+      - name: Setup ROS2 workspace
+        run: |
+          mkdir -p my_workspace/src
+          ln -s $GITHUB_WORKSPACE my_workspace/src/liodom
+
+      - name: Install dependencies with Conan
+        run: |
+          cd my_workspace
+          conan install src/liodom --output-folder=build/liodom --build=missing
+
+      - name: Build with colcon
+        run: |
+          source /opt/ros/kilted/setup.bash
+          cd my_workspace
+          colcon build --packages-select liodom \
+            --cmake-args \
+              -DCMAKE_TOOLCHAIN_FILE=${PWD}/build/liodom/conan_toolchain.cmake \
+              -DCMAKE_BUILD_TYPE=Release
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,59 @@
-.vscode/
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+######## VsCode ########
+
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+######## CMake ########
+CMakeUserPresets.json
+
+######## ROS ########
+
+# Ignore auto-generated logging configuration
+config/logging.conf
+
+# Ignore generated .launch files
+*.launch
+

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@
 *.app
 
 ######## VsCode ########
-
+.vscode
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json
@@ -56,4 +56,5 @@ config/logging.conf
 
 # Ignore generated .launch files
 *.launch
-
+temp.*
+note.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
-cmake_minimum_required(VERSION 3.5)
-project(liodom LANGUAGES CXX)
+cmake_minimum_required(VERSION 3.10)
+cmake_policy(SET CMP0057 NEW)
+
+project(liodom LANGUAGES C CXX)
 
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
@@ -7,72 +9,108 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+    add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake REQUIRED)
-find_package(rclcpp)
-find_package(std_msgs)
-find_package(geometry_msgs)
-find_package(nav_msgs)
-find_package(sensor_msgs)  
-find_package(tf2)
-find_package(tf2_eigen)
-find_package(tf2_ros)
-find_package(pcl_conversions)
-find_package(pcl_ros)
+# Add cmake modules from the cmake-directory
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-find_package(PCL REQUIRED)
-find_package(Eigen3)
-find_package(Ceres REQUIRED)
+# Non-ROS2 packages
+find_package(PCL 1.13 REQUIRED)
+find_package(EIGEN3)
+find_package(Ceres 2.0 REQUIRED)
 find_package(OpenMP REQUIRED)
-if (OPENMP_FOUND)
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-endif()
+
+# ROS2 packages
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(tf2 REQUIRED )
+find_package(tf2_eigen REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(pcl_conversions REQUIRED)
+find_package(pcl_ros REQUIRED)
 
 ###########
 ## Build ##
 ###########
 
-include_directories(include
-                    ${PCL_INCLUDE_DIRS}
-                    ${EIGEN3_INCLUDE_DIRS}
-                    ${CERES_INCLUDE_DIRS})
-# link_directories(${PCL_LIBRARY_DIRS})
-# add_definitions(${PCL_DEFINITIONS})
-
-### Targets ###
-# Set library sources
-set(${PROJECT_NAME}_sources
-      src/shared_data.cc
-      src/stats.cc
-      src/params.cc
-      src/feature_extractor.cc
-      src/laser_odometry.cc)
-
-#### Laser Odometry
+#### Laser Odometry ####
 add_executable(liodom_node
-      src/liodom_node.cc
-      ${${PROJECT_NAME}_sources})
-target_link_libraries(liodom_node ${PCL_LIBRARIES} ${CERES_LIBRARIES})
-ament_target_dependencies(liodom_node rclcpp std_msgs geometry_msgs nav_msgs sensor_msgs tf2 tf2_eigen tf2_ros pcl_conversions pcl_ros)
+    src/liodom_node.cc
+    src/shared_data.cc
+    src/stats.cc
+    src/params.cc
+    src/feature_extractor.cc
+    src/laser_odometry.cc
+)
 
-# #### Laser Mapping
+target_include_directories(liodom_node
+    PUBLIC 
+        $<INSTALL_INTERFACE:include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+
+target_link_libraries(
+    liodom_node
+    PRIVATE
+        rclcpp::rclcpp
+        ${std_msgs_TARGETS}
+        ${geometry_msgs_TARGETS}
+        ${nav_msgs_TARGETS}
+        sensor_msgs::sensor_msgs_library
+        tf2::tf2
+        tf2_ros::tf2_ros
+        pcl_conversions::pcl_conversions
+        PCL::PCL
+        Ceres::ceres
+        OpenMP::OpenMP_CXX
+)
+
+#### Laser Mapping ####
 add_executable(liodom_mapping
-               src/map.cc
-               src/liodom_mapping_node.cc)
-target_link_libraries(liodom_mapping ${PCL_LIBRARIES})
-ament_target_dependencies(liodom_mapping rclcpp std_msgs geometry_msgs nav_msgs sensor_msgs tf2 tf2_eigen tf2_ros pcl_conversions pcl_ros)
+    src/map.cc
+    src/liodom_mapping_node.cc
+)
+
+target_include_directories(liodom_mapping
+    PUBLIC 
+        $<INSTALL_INTERFACE:include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+
+target_link_libraries(liodom_mapping
+    PUBLIC
+        rclcpp::rclcpp
+        ${std_msgs_TARGETS}
+        ${geometry_msgs_TARGETS}
+        ${nav_msgs_TARGETS}
+        sensor_msgs::sensor_msgs_library
+        tf2::tf2
+        tf2_ros::tf2_ros
+        tf2_eigen::tf2_eigen
+        pcl_conversions::pcl_conversions
+        PCL::PCL
+        OpenMP::OpenMP_CXX
+)
 
 install(TARGETS
-  liodom_node
-  liodom_mapping
-  DESTINATION lib/${PROJECT_NAME}
+    liodom_node
+    liodom_mapping
+    DESTINATION lib/${PROJECT_NAME}
 )
 
 install(DIRECTORY 
-  launch
-  rviz 
-  DESTINATION share/${PROJECT_NAME})
+    launch
+    rviz 
+    DESTINATION share/${PROJECT_NAME}
+)
 
 ament_package()

--- a/README.md
+++ b/README.md
@@ -35,17 +35,78 @@ If you use this code, please cite as:
 # Installation
 
 ## Prerequisites
-- Tested on [Ubuntu 64-bit 20.04](http://ubuntu.com/download/desktop)
-- Tested on [ROS2 Foxy](https://docs.ros.org/en/foxy/index.html)
-- [Ceres](http://ceres-solver.org/installation.html)
-- [PCL](http://pointclouds.org/)
+
+- Tested on [Ubuntu 64-bit 24.04](http://ubuntu.com/download/desktop)
+- Tested on [ROS2 Kilted](https://docs.ros.org/en/kilted/index.html)
+- [CMake 3.28.3](https://cmake.org/download/)
+- [Conan 2.17](https://conan.io/)
+    - Conan is used for handling 3rd party libraries
+
+## Adding ROS 2 Packages
+
+First add ROS 2 to APT sources:
+
+```bash
+sudo apt install software-properties-common
+sudo add-apt-repository universe
+sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc -o /etc/apt/trusted.gpg.d/ros.asc
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/trusted.gpg.d/ros.asc] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+sudo apt update
+```
+
+## Installing Prerequisites
+
+First install ROS 2, Python, build-essential, cmake and Python packages using `apt`:
+
+```bash
+sudo apt-get install ros-kilted-desktop ros-kilted-pcl-ros ros-kilted-pcl-conversions ros-kilted-ament-cmake \
+    build-essential python3 python-is-python3 python3-colcon-common-extensions pipx cmake libudev-dev
+```
+
+After that install Conan and detect what compilers have been installed:
+
+```bash
+pipx install conan
+conan profile detect
+```
 
 ## Build
+
+Create a workspace and clone `liodom`:
+
+```bash
+mkdir my_workspace/src
+cd my_workspace/src
+git clone https://github.com/emiliofidalgo/liodom.git
 ```
-  cd ~/your_workspace/src
-  git clone https://github.com/emiliofidalgo/liodom.git
-  cd ..
-  colcon build --symlink-install --cmake-args ' -DCMAKE_BUILD_TYPE=Release'
+
+After having cloned the repository, checkout the correct branch. At the time of writing this document, ROS 2 version is in branch `ros2`.
+
+Once you have cloned the repository, and checked out the correct branch, you need to install the 3rd party libraries using Conan.
+When running this for the first time, it will take some time to build the packages (unless pre-built binaries exist).
+Built binaries are stored in a local cache, so when running for the second time, these are used:
+
+```bash
+cd my_workspace
+conan install src/liodom --output-folder=build/liodom --build=missing
+```
+
+And finally build the binaries:
+
+```bash
+source /opt/ros/kilted/setup.bash
+colcon build --packages-select liodom \
+    --cmake-args \
+        -DCMAKE_TOOLCHAIN_FILE=${PWD}/build/liodom/conan_toolchain.cmake \
+        -DCMAKE_BUILD_TYPE=Release
+```
+
+The toolchain file `conan_toolchain.cmake` tells CMake where Conan binaries can be found so that `find_package` works correctly. Above
+command installs the package in `my_workspace/install`. In order to make the installed packages visible to the system, run the following:
+
+```bash
+cd my_workspace
+source install/setup.bash
 ```
 
 # Usage
@@ -64,4 +125,6 @@ Reducing the values of these parameters may speed up LiODOM, sacrificing accurac
 If you have problems or questions using this code, please contact the author (emilio.garcia@uib.es). [Feature requests](http://github.com/emiliofidalgo/liodom/issues) and [contributions](http://github.com/emiliofidalgo/liodom/pulls) are totally welcome.
 
 # Acknowledgements
-Thanks to the authors of [A-LOAM](https://github.com/HKUST-Aerial-Robotics/A-LOAM) and [F-LOAM](https://github.com/wh200720041/floam) for publishing their codes. Some parts of this library are inspired from them.
+
+Thanks to the authors of [A-LOAM](https://github.com/HKUST-Aerial-Robotics/A-LOAM) and [F-LOAM](https://github.com/wh200720041/floam) for publishing their codes. Some parts of this library are inspired by those code bases.
+

--- a/cmake/FindEIGEN3.cmake
+++ b/cmake/FindEIGEN3.cmake
@@ -1,0 +1,37 @@
+# ------------------------------------------------------------------------------
+# FindEIGEN3.cmake
+#
+# Compatibility shim for legacy packages expecting EIGEN3-style CMake variables
+# and targets. This module ensures interoperability with packages like pcl_ros
+# that rely on deprecated conventions.
+#
+# This file assumes that find_package(Eigen3 REQUIRED) has already been called.
+#
+# Targets Provided:
+#   - EIGEN3::EIGEN3 (ALIAS of Eigen3::Eigen, if it exists)
+#
+# Variables Exported:
+#   - EIGEN3_FOUND: Always TRUE (indicates Eigen3 was found)
+#   - EIGEN3_INCLUDE_DIRS: Set from Eigen3_INCLUDE_DIRS
+#   - EIGEN3_LIBRARIES: Empty string (Eigen is header-only)
+# ------------------------------------------------------------------------------
+
+# Require Eigen3 to be found beforehand
+find_package(Eigen3 REQUIRED)
+
+# Define legacy alias target if not already defined
+# Some older packages (e.g., pcl_ros) expect EIGEN3::EIGEN3 instead of Eigen3::Eigen
+if(NOT TARGET EIGEN3::EIGEN3 AND TARGET Eigen3::Eigen)
+  add_library(EIGEN3::EIGEN3 ALIAS Eigen3::Eigen)
+endif()
+
+# Export expected legacy variables to mimic classic FindEIGEN3 behavior
+
+# Mark Eigen3 as found
+set(EIGEN3_FOUND TRUE)
+
+# Export include directories (may be empty if not defined upstream)
+set(EIGEN3_INCLUDE_DIRS ${Eigen3_INCLUDE_DIRS})
+
+# Eigen3 is header-only; no library to link against
+set(EIGEN3_LIBRARIES "")

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,14 @@
+[requires]
+pcl/1.13.1
+eigen/3.4.0
+ceres-solver/2.0.0
+
+[generators]
+CMakeToolchain
+CMakeDeps
+
+[options]
+ceres-solver/*:shared=False
+pcl/*:shared=False
+eigen/*:shared=False
+

--- a/launch/liodom_launch.xml
+++ b/launch/liodom_launch.xml
@@ -1,7 +1,7 @@
 <launch>
   
-  <arg name="viz" default="false" />
-  <arg name="mapping" default="false" />
+  <arg name="viz" default="true" />
+  <arg name="mapping" default="true" />
 
   <!-- Liodom -->
   <node pkg="liodom"
@@ -18,12 +18,12 @@
     <param name="scan_regions" value="8" />
     <param name="edges_per_region" value="10" />
     <param name="prev_frames" value="15" />
-    <param name="fixed_frame" value="odom" />
-    <param name="base_frame" value="base_link" />
+    <param name="fixed_frame" value="world" />
+    <param name="base_frame" value="camera_gray_left" />
     <param name="laser_frame" value="velo_link" />
     <param name="use_imu" value="false" />
-    <param name="save_results" value="false" />    
-    <param name="save_results_dir" value="/home/emilio/Escritorio/results/liodom/" />
+    <param name="save_results" value="true" />    
+    <param name="save_results_dir" value="/home/joaquinecc/Documents/ros_projects/results/" />
     <param name="mapping" value="$(var mapping)" />
     <param name="publish_tf" value="true" />
     <param name="use_sim_time" value="true"/>
@@ -48,7 +48,7 @@
       <param name="cells_xy" value="3" />
       <param name="cells_z" value="2" />
       <param name="fixed_frame" value="world" />
-      <param name="base_frame" value="base_link" />
+      <param name="base_frame" value="velo_link" />
       <param name="use_sim_time" value="true"/>
       
       <remap from="points" to="/liodom/edges" />
@@ -59,16 +59,17 @@
   <node pkg="tf2_ros"
         exec="static_transform_publisher"
 	      name="world2odom"
-	      args="0 0 0 0 0 0 world odom" >
+	      args="0 0 0 0 0 0 camera_gray_left odom" >
         <param name="use_sim_time" value="true"/>
   </node>
+  <!--
 
   <node pkg="tf2_ros"
         exec="static_transform_publisher"
 	      name="baselink2laser"
 	      args="0 0 0 0 0 0 base_link velo_link" >
         <param name="use_sim_time" value="true"/>
-  </node>
+  </node> -->
 
   <group if="$(var viz)">
     <node exec="rviz2" name="rviz2" pkg="rviz2" args="-d $(find-pkg-share liodom)/rviz/liodom.rviz">

--- a/launch/liodom_launch.xml
+++ b/launch/liodom_launch.xml
@@ -18,10 +18,10 @@
     <param name="scan_regions" value="8" />
     <param name="edges_per_region" value="10" />
     <param name="prev_frames" value="15" />
-    <param name="fixed_frame" value="world" />
-    <param name="base_frame" value="camera_gray_left" />
+    <param name="fixed_frame" value="odom" />
+    <param name="base_frame" value="base_link" />
     <param name="laser_frame" value="velo_link" />
-    <param name="use_imu" value="false" />
+    <param name="use_imu" value="true" />
     <param name="save_results" value="true" />    
     <param name="save_results_dir" value="/home/joaquinecc/Documents/ros_projects/results/" />
     <param name="mapping" value="$(var mapping)" />
@@ -29,6 +29,7 @@
     <param name="use_sim_time" value="true"/>
     
     <remap from="points" to="/kitti/velo/pointcloud" />
+<remap from="imu" to="/kitti/oxts/imu" />
     <remap from="map" to="/liodom_mapper/map_local" />
 
   </node>
@@ -47,7 +48,7 @@
       <param name="resolution" value="0.4" />    
       <param name="cells_xy" value="3" />
       <param name="cells_z" value="2" />
-      <param name="fixed_frame" value="world" />
+      <param name="fixed_frame" value="odom" />
       <param name="base_frame" value="velo_link" />
       <param name="use_sim_time" value="true"/>
       
@@ -56,14 +57,14 @@
     </node>
   </group>
 
-  <node pkg="tf2_ros"
+ <!-- <node pkg="tf2_ros"
         exec="static_transform_publisher"
 	      name="world2odom"
 	      args="0 0 0 0 0 0 camera_gray_left odom" >
         <param name="use_sim_time" value="true"/>
-  </node>
+  </node> -->
   <!--
-
+true
   <node pkg="tf2_ros"
         exec="static_transform_publisher"
 	      name="baselink2laser"

--- a/launch/liodom_ouster_launch.xml
+++ b/launch/liodom_ouster_launch.xml
@@ -1,8 +1,10 @@
 <launch>
 
   <arg name="viz" default="false" />
-  <arg name="mapping" default="false" />  
-
+  <arg name="mapping" default="true" />  
+  <arg name="use_imu" default="false" />
+  <arg name="scan_regions" default="8" />
+  <arg name="edges_per_region" default="10" />
   <!-- Liodom -->
   <node pkg="liodom"
         exec="liodom_node"
@@ -21,15 +23,16 @@
     <param name="fixed_frame" value="odom" />
     <param name="base_frame" value="base_link" />
     <param name="laser_frame" value="" />
-    <param name="use_imu" value="false" />
+    <param name="use_imu" value="$(var use_imu)" />
     <param name="save_results" value="true" />
     <param name="save_results_dir" value="/home/emilio/Escritorio/results/" />
-    <param name="mapping" value="$(arg mapping)" />
+    <param name="mapping" value="$(var mapping)" />
     <param name="publish_tf" value="true" />
     <param name="use_sim_time" value="true"/>
     
-    <remap from="points" to="/os_cloud_node/points" />
+    <remap from="points" to="/ouster/points" />
     <remap from="map" to="/liodom_mapper/map_local" />
+    <remap from="imu" to="/ouster/imu" />
 
   </node> 
 
@@ -57,18 +60,18 @@
   </group> 
 
   <node pkg="tf2_ros"
-        type="static_transform_publisher"
+        exec="static_transform_publisher"
 	      name="map2odom"
 	      args="0 0 0 0 0 0 map odom" >
         <param name="use_sim_time" value="true"/>
   </node>
 
-  <node pkg="tf2_ros" 
-        type="static_transform_publisher" 
+  <!-- <node pkg="tf2_ros" 
+        exec="static_transform_publisher" 
 	      name="bl2os1"
-	      args="0 0 0 0 0 0 base_link os_sensor" >
+	      args="0 0 0 0 0 0 base_link z" >
         <param name="use_sim_time" value="true"/>
-  </node>
+  </node> -->
 
   <!--node pkg="tf"
         type="static_transform_publisher" 

--- a/package.xml
+++ b/package.xml
@@ -2,29 +2,39 @@
 <?xml-model
    href="http://download.ros.org/schema/package_format3.xsd"
    schematypens="http://www.w3.org/2001/XMLSchema"?>
-  <package format="3">
+<package format="3">
 
   <name>liodom</name>
   <version>0.1.0</version>
   <description>Lidar Odometry</description>
+
   <maintainer email="emilio.garcia@uib.es">Emilio Garcia-Fidalgo</maintainer>
   <license>GPLv3</license>
-  
+
+  <!-- Build system -->
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <!-- Core ROS 2 dependencies -->
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
-  <depend>sensor_msgs</depend>  
+  <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>
   <depend>tf2_ros</depend>
+
+  <!-- PCL-related -->
   <depend>pcl_conversions</depend>
   <depend>pcl_ros</depend>
+
+  <!-- Optional ROS tools -->
   <exec_depend>ros2launch</exec_depend>
-  <!-- <depend>tf_conversions</depend> -->
-  <!-- <depend>eigen_conversions</depend> -->
+
+  <!-- External dependencies (non-ROS) -->
+  <depend version_eq="1.13.1">pcl</depend>
+  <depend version_eq="3.4.0">eigen</depend>
+  <depend version_eq="2.0.0">ceres-solver</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rviz/liodom.rviz
+++ b/rviz/liodom.rviz
@@ -6,9 +6,11 @@ Panels:
       Expanded:
         - /Global Options1
         - /Edges1/Topic1
+        - /Velodyne1
         - /Odometry1/Shape1
+        - /Path1
       Splitter Ratio: 0.5
-    Tree Height: 708
+    Tree Height: 1747
   - Class: rviz_common/Selection
     Name: Selection
   - Class: rviz_common/Tool Properties
@@ -29,7 +31,7 @@ Visualization Manager:
       Cell Size: 1
       Class: rviz_default_plugins/Grid
       Color: 160; 160; 164
-      Enabled: false
+      Enabled: true
       Line Style:
         Line Width: 0.029999999329447746
         Value: Lines
@@ -42,7 +44,7 @@ Visualization Manager:
       Plane: XY
       Plane Cell Count: 10
       Reference Frame: <Fixed Frame>
-      Value: false
+      Value: true
     - Alpha: 1
       Autocompute Intensity Bounds: true
       Autocompute Value Bounds:
@@ -55,7 +57,7 @@ Visualization Manager:
       Color: 239; 41; 41
       Color Transformer: FlatColor
       Decay Time: 0
-      Enabled: false
+      Enabled: true
       Invert Rainbow: false
       Max Color: 255; 255; 255
       Max Intensity: 0.7699999809265137
@@ -68,14 +70,14 @@ Visualization Manager:
       Size (m): 0.10000000149011612
       Style: Flat Squares
       Topic:
-        Depth: 0
+        Depth: 1
         Durability Policy: Volatile
         History Policy: Keep Last
         Reliability Policy: Reliable
         Value: /liodom/edges
       Use Fixed Frame: true
       Use rainbow: true
-      Value: false
+      Value: true
     - Alpha: 1
       Autocompute Intensity Bounds: true
       Autocompute Value Bounds:
@@ -88,7 +90,7 @@ Visualization Manager:
       Color: 115; 210; 22
       Color Transformer: FlatColor
       Decay Time: 0
-      Enabled: false
+      Enabled: true
       Invert Rainbow: false
       Max Color: 255; 255; 255
       Max Intensity: 0.9900000095367432
@@ -105,10 +107,10 @@ Visualization Manager:
         Durability Policy: Volatile
         History Policy: Keep Last
         Reliability Policy: Reliable
-        Value: /kitti/velo/pointcloud
+        Value: /liodom_mapper/map_local
       Use Fixed Frame: true
       Use rainbow: true
-      Value: false
+      Value: true
     - Angle Tolerance: 0.10000000149011612
       Class: rviz_default_plugins/Odometry
       Covariance:
@@ -143,14 +145,43 @@ Visualization Manager:
       Topic:
         Depth: 5
         Durability Policy: Volatile
+        Filter size: 10
         History Policy: Keep Last
         Reliability Policy: Reliable
         Value: /liodom/odom
       Value: true
+    - Alpha: 1
+      Buffer Length: 1
+      Class: rviz_default_plugins/Path
+      Color: 237; 51; 59
+      Enabled: true
+      Head Diameter: 0.30000001192092896
+      Head Length: 0.20000000298023224
+      Length: 0.30000001192092896
+      Line Style: Lines
+      Line Width: 0.029999999329447746
+      Name: Path
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Pose Color: 255; 85; 255
+      Pose Style: None
+      Radius: 0.029999999329447746
+      Shaft Diameter: 0.10000000149011612
+      Shaft Length: 0.10000000149011612
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /kitti/gtruth/path
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
-    Fixed Frame: world
+    Fixed Frame: map
     Frame Rate: 30
   Name: root
   Tools:
@@ -162,6 +193,9 @@ Visualization Manager:
     - Class: rviz_default_plugins/Measure
       Line color: 128; 128; 0
     - Class: rviz_default_plugins/SetInitialPose
+      Covariance x: 0.25
+      Covariance y: 0.25
+      Covariance yaw: 0.06853891909122467
       Topic:
         Depth: 5
         Durability Policy: Volatile
@@ -190,7 +224,7 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz_default_plugins/Orbit
-      Distance: 401.53173828125
+      Distance: 353.5245056152344
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
@@ -205,24 +239,24 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 1.5697963237762451
+      Pitch: 0.8047964572906494
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 3.165393829345703
+      Yaw: 3.8053929805755615
     Saved: ~
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 1016
+  Height: 2083
   Hide Left Dock: false
   Hide Right Dock: true
-  QMainWindow State: 000000ff00000000fd0000000400000000000001560000039efc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d0000039e000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f0000039efc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d0000039e000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004420000003efc0100000002fb0000000800540069006d00650100000000000004420000000000000000fb0000000800540069006d00650100000000000004500000000000000000000005e40000039e00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd000000040000000000000160000007b9fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006f00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000048000007b9000000f300fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f0000039efc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d0000039e000000c500fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004420000003efc0100000002fb0000000800540069006d00650100000000000004420000000000000000fb0000000800540069006d0065010000000000000450000000000000000000000d57000007b900000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Tool Properties:
     collapsed: false
   Views:
     collapsed: true
-  Width: 1856
-  X: 64
-  Y: 27
+  Width: 3774
+  X: 66
+  Y: 40

--- a/src/laser_odometry.cc
+++ b/src/laser_odometry.cc
@@ -379,8 +379,8 @@ bool LaserOdometer::getBaseToLaserTf (const std::string& frame_id) {
   try {
     rclcpp::Time now = nh_->get_clock()->now();
     laser_to_base_tf = tf_buffer_->lookupTransform(
-      frame_id,
-      params->base_frame_,
+      params->base_frame_, // target frame
+      frame_id,  // source frame
       now,
       rclcpp::Duration(2.0, 0));
   } catch (const tf2::TransformException & ex) {
@@ -407,7 +407,7 @@ void LaserOdometer::publishOdom(const std_msgs::msg::Header& header, const Eigen
   laser_odom_msg.child_frame_id = params->base_frame_;
   laser_odom_msg.header.stamp = header.stamp;
   // Transform to base_link frame before publication
-  Eigen::Isometry3d odom_base_link = pose * laser_to_base_;
+  Eigen::Isometry3d odom_base_link = laser_to_base_* pose ;
   Eigen::Quaterniond q_current(odom_base_link.rotation());
   q_current.normalize();
 
@@ -422,7 +422,7 @@ void LaserOdometer::publishOdom(const std_msgs::msg::Header& header, const Eigen
   laser_odom_msg.pose.pose.position.z = t_current.z();
   //Filling twist
   double delta_time = rclcpp::Time(header.stamp).seconds() - prev_stamp_;
-  Eigen::Isometry3d delta_odom = ((prev_odom_ * laser_to_base_).inverse() * odom_base_link);
+  Eigen::Isometry3d delta_odom = ((laser_to_base_*prev_odom_ ).inverse() * odom_base_link);
   Eigen::Vector3d t_delta = delta_odom.translation();
   laser_odom_msg.twist.twist.linear.x = t_delta.x() / delta_time;
   laser_odom_msg.twist.twist.linear.y = t_delta.y() / delta_time;

--- a/src/laser_odometry.cc
+++ b/src/laser_odometry.cc
@@ -190,6 +190,8 @@ void LaserOdometer::operator()(std::atomic<bool>& running) {
 
         // Updating the initial guess
         Eigen::Quaterniond q_curr(odom_.rotation());
+        q_curr.normalize();
+
         param_q[0] = q_curr.x();
         param_q[1] = q_curr.y();
         param_q[2] = q_curr.z();
@@ -407,6 +409,8 @@ void LaserOdometer::publishOdom(const std_msgs::msg::Header& header, const Eigen
   // Transform to base_link frame before publication
   Eigen::Isometry3d odom_base_link = pose * laser_to_base_;
   Eigen::Quaterniond q_current(odom_base_link.rotation());
+  q_current.normalize();
+
   Eigen::Vector3d t_current = odom_base_link.translation();
   //Filling pose
   laser_odom_msg.pose.pose.orientation.x = q_current.x();

--- a/src/laser_odometry.cc
+++ b/src/laser_odometry.cc
@@ -167,7 +167,7 @@ void LaserOdometer::operator()(std::atomic<bool>& running) {
           imu_m.getRPY(imu_roll, imu_pitch, imu_yaw);
 
           //2.- rotate odom to frame baselink and get the orientation
-          Eigen::Isometry3d odom_bl = odom_ * laser_to_base_;
+          Eigen::Isometry3d odom_bl = odom_ ;
           Eigen::Quaterniond odom_ori_bl(odom_bl.rotation());
           tf2::Quaternion odom_bl_quat(odom_ori_bl.x(), odom_ori_bl.y(), odom_ori_bl.z(), odom_ori_bl.w());
           tf2::Matrix3x3 odom_bl_m(odom_bl_quat);
@@ -185,7 +185,7 @@ void LaserOdometer::operator()(std::atomic<bool>& running) {
           odom_bl.linear() = odom_ori_bl.toRotationMatrix();
 
           //5.- rotate odom back to frame laser
-          odom_ = odom_bl * (laser_to_base_.inverse());
+          odom_ = odom_bl;
         }
 
         // Updating the initial guess

--- a/src/liodom_mapping_node.cc
+++ b/src/liodom_mapping_node.cc
@@ -53,11 +53,11 @@ std::shared_ptr<tf2_ros::Buffer> tf_buffer;
 
 using namespace std::chrono_literals;
 
-void lidarClb(const sensor_msgs::msg::PointCloud2::SharedPtr lidar_msg) {
+void lidarClb(const sensor_msgs::msg::PointCloud2::SharedPtr edge_lidar_msg) {
   
   // Converting ROS message to PCL
   liodom::PointCloud::Ptr pc_new(new liodom::PointCloud);
-  pcl::fromROSMsg(*lidar_msg, *pc_new);
+  pcl::fromROSMsg(*edge_lidar_msg, *pc_new);
   RCLCPP_INFO(node->get_logger(), "Received cloud with %lu points.", pc_new->points.size());
 
   // Waiting for the current position
@@ -66,7 +66,7 @@ void lidarClb(const sensor_msgs::msg::PointCloud2::SharedPtr lidar_msg) {
     transform = tf_buffer->lookupTransform(
       fixed_frame,
       base_frame,
-      lidar_msg->header.stamp,
+      edge_lidar_msg->header.stamp,
       rclcpp::Duration(5.0, 0));
   } catch (const tf2::TransformException& ex) {    
     RCLCPP_WARN(node->get_logger(), "Could not get transform from %s to %s: %s", fixed_frame.c_str(), base_frame.c_str(), ex.what());
@@ -85,7 +85,7 @@ void lidarClb(const sensor_msgs::msg::PointCloud2::SharedPtr lidar_msg) {
     sensor_msgs::msg::PointCloud2 cloud_msg;
     pcl::toROSMsg(*map, cloud_msg);
     cloud_msg.header.frame_id = fixed_frame;
-    cloud_msg.header.stamp = lidar_msg->header.stamp;
+    cloud_msg.header.stamp = edge_lidar_msg->header.stamp;
     pc_pub->publish(cloud_msg);
   }
 
@@ -95,7 +95,7 @@ void lidarClb(const sensor_msgs::msg::PointCloud2::SharedPtr lidar_msg) {
     sensor_msgs::msg::PointCloud2 cloud_msg;
     pcl::toROSMsg(*map, cloud_msg);
     cloud_msg.header.frame_id = fixed_frame;
-    cloud_msg.header.stamp = lidar_msg->header.stamp;
+    cloud_msg.header.stamp = edge_lidar_msg->header.stamp;
     pc_pub_local->publish(cloud_msg);
   }
 
@@ -126,7 +126,7 @@ int main(int argc, char** argv) {
   node->declare_parameter("voxel_xysize", 40.0);
   node->declare_parameter("voxel_zsize", 50.0);
   node->declare_parameter("resolution", 0.4);
-  node->declare_parameter("fixed_frame", std::string("world"));
+  node->declare_parameter("fixed_frame", std::string("odom"));
   node->declare_parameter("base_frame", std::string("base_link"));
   node->declare_parameter("cells_xy", 2);
   node->declare_parameter("cells_z", 2);

--- a/src/liodom_mapping_node.cc
+++ b/src/liodom_mapping_node.cc
@@ -24,7 +24,7 @@
 
 // ROS
 #include <rclcpp/rclcpp.hpp>
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 #include <tf2_ros/transform_listener.h>
 #include <tf2_ros/buffer.h>
 #include <sensor_msgs/msg/point_cloud2.hpp>

--- a/src/map.cc
+++ b/src/map.cc
@@ -101,8 +101,8 @@ void Map::updateMap(const PointCloud::Ptr& pc_in, const Eigen::Isometry3d& pose)
 
 		// Compute the corresponding cell
     int voxel_x = int(std::floor(point.x * inv_voxel_xysize_) * voxel_xysize_ + (voxel_xysize_half_));
-    int voxel_y = int(std::floor(point.y * inv_voxel_xysize_) * voxel_xysize_ + (voxel_xysize_half_));
-    int voxel_z = int(std::floor(point.z * inv_voxel_zsize_) * voxel_zsize_ + (voxel_zsize_half_));
+    int voxel_y = int(std::floor(point.z * inv_voxel_xysize_) * voxel_xysize_ + (voxel_xysize_half_));
+    int voxel_z = int(std::floor(point.y * inv_voxel_zsize_) * voxel_zsize_ + (voxel_zsize_half_));
     
     // Check if the voxel is already in the map
     HashKey key(voxel_x, voxel_y, voxel_z);
@@ -144,10 +144,10 @@ PointCloud::Ptr Map::getLocalMap(const Eigen::Isometry3d& pose, int cells_xy, in
   int x = pose.translation().x();
   int voxel_x = int(std::floor(x * inv_voxel_xysize_) * voxel_xysize_ + (voxel_xysize_half_));
 
-  int y = pose.translation().y();
+  int y = pose.translation().z();
   int voxel_y = int(std::floor(y * inv_voxel_xysize_) * voxel_xysize_ + (voxel_xysize_half_));
 
-  int z = pose.translation().z();
+  int z = pose.translation().y();
   int voxel_z = int(std::floor(z * inv_voxel_zsize_) * voxel_zsize_ + (voxel_zsize_half_));
 
   // Final local map


### PR DESCRIPTION
# Conan Support

This PR modifies slightly the existing CMake based build system since ROS 2 is moving towards using modern CMake, based on targets. For example `ament_target_dependencies` has been deprecated and `target_link_libraries` is to be used instead. This is actually good news, since CMake is being developed rapidly and adding additional wrappers on top of CMake does not really make sense. Another change is that Conan is being used to handle 3rd party libraries, making it easier to maintain compatibility.

## GitHub Actions

This PR also adds a GitHub action that builds the package when making a PR. Currently building takes roughly 20min, this could be sped up by creating a Docker container with all of the required packages pre-built.

## Testing

The README.md contains all the instructions regarding how to install the dependencies and how to build the package. Please follow the instructions and if there are any problems, or missing information in the README.md, please leave comments in the PR.